### PR TITLE
Problemas al generar el diccionario en el formato datapackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ The ouptut will be in `client`
 ## Want to contribute?
 
 If you've found a bug or have a great idea for new feature let me know by [adding your suggestion]
-(http://github.com/mbaez/ddgenerate/issues/new) to [issues list](https://github.com/mbaez/ddgenerate/issues).
+(http://github.com/rparrapy/ddgenerate/issues/new) to [issues list](https://github.com/rparrapy/ddgenerate/issues).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# DDegenerate
+
+Data Dictionary generator.
+
+## Usage
+
+### Complie
+To compile ddgenerate :
+
+```sh
+$ cd ddgenerate/
+$ mvn clean compile assembly:single
+```
+
+### Run
+To run ddgenerate :
+
+```sh
+$ java -jar target/ddgenerate-1.0-SNAPSHOT-jar-with-dependencies.jar "<path_al_diccionario>/diccionario.xlsx" -f <format> -o <path_output>
+```
+
+Example :
+
+```sh
+$ java -jar target/ddgenerate-1.0-SNAPSHOT-jar-with-dependencies.jar "../diccionario.xlsx" -f datapackage -o ../client/
+
+```
+
+The ouptut will be in `client`
+
+## Want to contribute?
+
+If you've found a bug or have a great idea for new feature let me know by [adding your suggestion]
+(http://github.com/mbaez/ddgenerate/issues/new) to [issues list](https://github.com/mbaez/ddgenerate/issues).

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
     <properties>
         <slf4jVersion>1.7.7</slf4jVersion>
         <jdk.version>1.7</jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <build>


### PR DESCRIPTION
Se corrigen los problemas de generación del diccionario de datos en el formato `datapackage`. Las modificaciones fueron realizadas:
- Se modifica la forma de procesar los XLS debido que apache poi omite las celdas vacías causando que se genere de forma incorrecta schema json.
- Se añaden nuevos tipos XSD para que sean procesables
- Se corrige el encoding de los archivos a la hora de compilar.
